### PR TITLE
Update ecmaVersion to number instead of string

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   "parserOptions": {
-    "ecmaVersion": "6",
+    "ecmaVersion": 6,
     "sourceType": "module"
   },
   "env": {


### PR DESCRIPTION
Update ecmaVersion to allow eslinting to work. Otherwise throwing error: `Parsing error: ecmaVersion must be a number` instead of other showing other tests.